### PR TITLE
fix(map.lic): Stop stealing focus

### DIFF
--- a/scripts/map.lic
+++ b/scripts/map.lic
@@ -15,9 +15,12 @@ Tracks your current room on visual maps
       game: Gemstone
       tags: core, movement, mapping
       required: Lich > 5.0.1
-      version: 1.4.1
+      version: 1.4.2
 
   changelog:
+    v1.4.2 (2025-08-08)
+      * Doesn't take focus on launch
+      * Returns focus to wrayth after click
     v1.4.1 (2025-07-08)
       * Handle a location of false
     v1.4.0 (2025-07-04)
@@ -126,6 +129,89 @@ unless defined?(Gtk.queue)
   respond
   exit
 end
+
+require 'fiddle'
+require 'fiddle/import'
+
+def detect_platform
+  case RUBY_PLATFORM
+  when /mingw|mswin/ then :windows
+  when /darwin/      then :macos
+  when /linux/       then :linux
+  else                    :unsupported
+  end
+end
+
+# Windows
+if detect_platform == :windows
+  module WinAPI
+    extend Fiddle::Importer
+    dlload 'user32.dll'
+    extern 'int EnumWindows(void*, long)'
+    extern 'int GetWindowTextA(void*, void*, int)'
+    extern 'int IsWindowVisible(void*)'
+    extern 'int SetForegroundWindow(void*)'
+  end
+
+  def focus_wrayth_windows
+    hwnd_holder = Fiddle::Pointer.malloc(Fiddle::SIZEOF_VOIDP)
+    enum_proc = Fiddle::Closure::BlockCaller.new(Fiddle::TYPE_INT, [Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG]) do |hwnd, _|
+      next 1 if WinAPI.IsWindowVisible(hwnd) == 0
+      buffer = "\0" * 512
+      WinAPI.GetWindowTextA(hwnd, buffer, 512)
+      title = buffer.delete("\0")
+      if title.include?("Wrayth") || title.include?("GemStone")
+        hwnd_holder[0, Fiddle::SIZEOF_VOIDP] = [hwnd].pack('L!')
+        0 # Stop
+      else
+        1
+      end
+    end
+
+    WinAPI.EnumWindows(enum_proc, 0)
+    hwnd = hwnd_holder[0, Fiddle::SIZEOF_VOIDP].unpack1('L!')
+
+    if hwnd && hwnd != 0
+      -> { WinAPI.SetForegroundWindow(hwnd) }
+    else
+      puts "Wrayth window not found."
+      nil
+    end
+  end
+end
+
+# macOS
+def focus_wrayth_mac
+  if system("which osascript > /dev/null 2>&1")
+    -> {
+      system(%q[osascript -e 'tell application "System Events" to tell process "Wrayth" to set frontmost to true'])
+    }
+  else
+    puts "osascript not found."
+    nil
+  end
+end
+
+# Linux
+def focus_wrayth_linux
+  if system("which xdotool > /dev/null 2>&1")
+    -> {
+      system("xdotool search --name Wrayth windowactivate")
+    }
+  else
+    puts "xdotool not found. Install it with: sudo apt install xdotool"
+    nil
+  end
+end
+
+FOCUS_WRAYTH = case detect_platform
+               when :windows then defined?(focus_wrayth_windows) ? focus_wrayth_windows : nil
+               when :macos   then focus_wrayth_mac
+               when :linux   then focus_wrayth_linux
+               else
+                 puts "Unsupported platform for Wrayth focus"
+                 nil
+               end || -> {}
 
 if Script.current.vars[1] == 'help'
   echo "Version: #{(Script.list.find { |x| x.name == Script.current.name }.inspect)[/version: (\d+\.\d+\.\d+)/i, 1]}                                                                              "
@@ -645,6 +731,8 @@ Gtk.queue {
   window = Gtk::Window.new
   window.title = "Map: #{Char.name}"
   window.set_icon(@default_icon)
+  window.accept_focus = false
+  window.focus_on_map = false
   window.signal_connect('delete_event') { narost_exit = true }
   window.signal_connect("size-allocate") do
     window_resized = true
@@ -664,12 +752,18 @@ Gtk.queue {
       # echo "offsetx: #{window_offset_x} offsety: #{window_offset_y}"
     end
   end
+  window.signal_connect("focus-in-event") do |_widget, _event|
+    GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
+    false
+  end
+
   scroller = Gtk::ScrolledWindow.new
   scroller.border_width = 0
   setting_hide_scrollbars ? scroller.set_policy(:never, :never) : scroller.set_policy(:automatic, :always)
   window.add(scroller)
 
   layout = Gtk::Layout.new
+
   scroller.add(layout)
 
   image = Gtk::Image.new
@@ -1039,6 +1133,7 @@ Gtk.queue {
               size = ((([click_x, fix_click[0]].max - [click_x, fix_click[0]].min) + ([click_y, fix_click[1]].max - [click_y, fix_click[1]].min)) / 2).round
               current_room = $narost_fake_room || Room.current
               respond "#{current_room.id}; x: #{x}, y: #{y}, size: #{size}"
+              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
               if defined?(current_room.image_coords)
                 current_room.image = map_name
                 current_room.image_coords = [[fix_click[0].round, click_x.round].min, [fix_click[1].round, click_y.round].min, [fix_click[0].round, click_x.round].max, [fix_click[1].round, click_y.round].max]
@@ -1052,13 +1147,16 @@ Gtk.queue {
             end
           elsif ev.state.inspect =~ /control-mask/
             respond "x: #{click_x}, y: #{click_y}"
+            GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
           elsif ev.state.inspect =~ /shift-mask/
             if (clicked_room = find_clicked_room.call(click_x, click_y))
               respond
               respond clicked_room
               respond
+              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
             else
               respond '[map: no matching room found]'
+              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
             end
           else
             if (clicked_link = find_clicked_link(current_map, click_x, click_y))
@@ -1067,8 +1165,10 @@ Gtk.queue {
               scroller.vadjustment.value = clicked_link[2].to_i * scale
             elsif (clicked_room = find_clicked_room.call(click_x, click_y))
               start_script 'go2', [clicked_room.id.to_s, '_disable_confirm_']
+              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
             else
               respond '[map: no matching room found]'
+              GLib::Timeout.add(50) { FOCUS_WRAYTH.call; false }
             end
           end
         end
@@ -1076,6 +1176,7 @@ Gtk.queue {
     }
   }
   setting_borderless ? window.set_decorated(false) : window.set_decorated(true)
+
   window.show_all
 
   # Get the default display and primary monitor


### PR DESCRIPTION
I'm not sure how everyone would feel about this being that it's not a universal solution and requires platform dependent api calls.
Thought I would put it up to see though. If worth it, maybe could be core lich and implemented into all the gtk windows.

Keeps full functionality and returns focus back to wrayth after clicks. Right click menu still works as expected.
Tested on Wrayth and Wizard.

Prevents gtk window from taking focus upon launch.

Return focus to wrayth after clicking when using platform native api's Fiddle for windows comes with ruby install
osascript for mac comes native with mac
xdotool for linux needs to be installed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes focus issue in `map.lic` by preventing GTK window from taking focus on launch and returning focus to Wrayth after interactions using platform-specific APIs.
> 
>   - **Behavior**:
>     - Prevents GTK window in `map.lic` from taking focus on launch.
>     - Returns focus to Wrayth after clicking using platform-specific APIs.
>   - **Platform-Specific Implementations**:
>     - Windows: Uses `Fiddle` to interact with `user32.dll` for window focus management.
>     - macOS: Uses `osascript` to set Wrayth as the frontmost application.
>     - Linux: Uses `xdotool` to activate the Wrayth window.
>   - **Misc**:
>     - Updates version to 1.4.2 in `map.lic` changelog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Nisugi%2Fscripts&utm_source=github&utm_medium=referral)<sup> for b879723393846016a3dad6a635933fe1d7d5cad9. You can [customize](https://app.ellipsis.dev/Nisugi/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->